### PR TITLE
Updated default code scheme count to 1

### DIFF
--- a/src/engagement_db_coda_sync/configuration.py
+++ b/src/engagement_db_coda_sync/configuration.py
@@ -8,7 +8,7 @@ from core_data_modules.data_models import CodeScheme
 class CodeSchemeConfiguration:
     code_scheme: CodeScheme
     auto_coder: Optional[Callable[[str], str]]
-    coda_code_schemes_count: Optional[int] = 3
+    coda_code_schemes_count: Optional[int] = 1
 
 
 @dataclass


### PR DESCRIPTION
It will be easier to increase the number of duplicate code schemes in coda when required than reducing because if you reduce the number of code scheme count in CodeSchemeConfiguration it doesn't effect the change you have to manually delete the code schemes in firebase. 
For example in RVI I didn't set code scheme count to 1 for coda IMAQAL_location dataset earlier so it defaulted to 3. IMAQAL_location requires at least 5 code schemes, this meant we had 10 additional code schemes which didn't fit in coda well and couldn't be reverted by changing the configs, so I had to go through 28 segments deleting the duplicate code schemes.