### PR TITLE
Enable skipping updating coda users & code schemes

### DIFF
--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -31,7 +31,7 @@ ARCHIVE_FILE="$ARCHIVE_LOCATION/data-$RUN_ID.tar.gzip"
 ./docker-sync-engagement-db-to-coda.sh --incremental-cache-volume "$PIPELINE_NAME-engagement-db-to-coda-cache" "$USER" \
                         "$GOOGLE_CLOUD_CREDENTIALS_PATH" "$CONFIGURATION_MODULE" "$DATA_DIR"
 
-./docker-sync-coda-to-engagement-db.sh --incremental-cache-volume "$PIPELINE_NAME-coda-to-engagement-db-cache" "$USER" \
+./docker-sync-coda-to-engagement-db.sh --incremental-cache-volume -s "$PIPELINE_NAME-coda-to-engagement-db-cache" "$USER" \
                         "$GOOGLE_CLOUD_CREDENTIALS_PATH" "$CONFIGURATION_MODULE" "$DATA_DIR"
 
 ./docker-run-engagement-db-to-analysis.sh --incremental-cache-volume "$PIPELINE_NAME-engagement-db-to-analysis-cache" \

--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -31,7 +31,7 @@ ARCHIVE_FILE="$ARCHIVE_LOCATION/data-$RUN_ID.tar.gzip"
 ./docker-sync-engagement-db-to-coda.sh --incremental-cache-volume "$PIPELINE_NAME-engagement-db-to-coda-cache" "$USER" \
                         "$GOOGLE_CLOUD_CREDENTIALS_PATH" "$CONFIGURATION_MODULE" "$DATA_DIR"
 
-./docker-sync-coda-to-engagement-db.sh --incremental-cache-volume -s "$PIPELINE_NAME-coda-to-engagement-db-cache" "$USER" \
+./docker-sync-coda-to-engagement-db.sh --incremental-cache-volume --skip-updating-coda-users-and-code-schemes "$PIPELINE_NAME-coda-to-engagement-db-cache" "$USER" \
                         "$GOOGLE_CLOUD_CREDENTIALS_PATH" "$CONFIGURATION_MODULE" "$DATA_DIR"
 
 ./docker-run-engagement-db-to-analysis.sh --incremental-cache-volume "$PIPELINE_NAME-engagement-db-to-analysis-cache" \

--- a/src/engagement_db_coda_sync/lib.py
+++ b/src/engagement_db_coda_sync/lib.py
@@ -20,7 +20,7 @@ def _get_coda_users_from_gcloud(dataset_users_file_url, google_cloud_credentials
     ))
 
 
-def ensure_coda_datasets_up_to_date(coda, coda_config, google_cloud_credentials_file_path, dry_run): 
+def ensure_coda_users_and_code_schemes_up_to_date(coda, coda_config, google_cloud_credentials_file_path, dry_run): 
     """
     Ensures coda datasets are up to date based on coda configuration. 
 

--- a/src/engagement_db_coda_sync/lib.py
+++ b/src/engagement_db_coda_sync/lib.py
@@ -22,7 +22,7 @@ def _get_coda_users_from_gcloud(dataset_users_file_url, google_cloud_credentials
 
 def ensure_coda_users_and_code_schemes_up_to_date(coda, coda_config, google_cloud_credentials_file_path, dry_run): 
     """
-    Ensures coda datasets are up to date based on coda configuration. 
+    Ensures coda users and code schemes are up to date.
 
     :param coda: Coda instance to add the message to.
     :type coda: coda_v2_python_client.firebase_client_wrapper.CodaV2Client

--- a/sync_coda_to_engagement_db.py
+++ b/sync_coda_to_engagement_db.py
@@ -17,6 +17,8 @@ if __name__ == "__main__":
                         help="Logs the updates that would be made without updating anything.")
     parser.add_argument("--incremental-cache-path",
                         help="Path to a directory to use to cache results needed for incremental operation.")
+    parser.add_argument("-s", "--skip-coda-users-and-code-schemes-update", action="store_true",
+                        help="Whether to skip coda users and code schemes updates")
     parser.add_argument("user", help="Identifier of the user launching this program")
     parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
                         help="Path to a Google Cloud service account credentials file to use to access the "
@@ -51,5 +53,6 @@ if __name__ == "__main__":
     engagement_db = pipeline_config.engagement_database.init_engagement_db_client(google_cloud_credentials_file_path)
     coda = pipeline_config.coda_sync.coda.init_coda_client(google_cloud_credentials_file_path)
 
-    ensure_coda_datasets_up_to_date(coda, pipeline_config.coda_sync.sync_config, google_cloud_credentials_file_path, dry_run)
+    if not args.skip_coda_users_and_code_schemes_update:
+        ensure_coda_datasets_up_to_date(coda, pipeline_config.coda_sync.sync_config, google_cloud_credentials_file_path, dry_run)
     sync_coda_to_engagement_db(coda, engagement_db, pipeline_config.coda_sync.sync_config, incremental_cache_path, dry_run)

--- a/sync_coda_to_engagement_db.py
+++ b/sync_coda_to_engagement_db.py
@@ -6,7 +6,7 @@ from core_data_modules.logging import Logger
 from engagement_database.data_models import HistoryEntryOrigin
 
 from src.engagement_db_coda_sync.coda_to_engagement_db import sync_coda_to_engagement_db
-from src.engagement_db_coda_sync.lib import ensure_coda_datasets_up_to_date
+from src.engagement_db_coda_sync.lib import ensure_coda_users_and_code_schemes_up_to_date
 
 log = Logger(__name__)
 
@@ -54,5 +54,5 @@ if __name__ == "__main__":
     coda = pipeline_config.coda_sync.coda.init_coda_client(google_cloud_credentials_file_path)
 
     if not args.skip_coda_users_and_code_schemes_update:
-        ensure_coda_datasets_up_to_date(coda, pipeline_config.coda_sync.sync_config, google_cloud_credentials_file_path, dry_run)
+        ensure_coda_users_and_code_schemes_up_to_date(coda, pipeline_config.coda_sync.sync_config, google_cloud_credentials_file_path, dry_run)
     sync_coda_to_engagement_db(coda, engagement_db, pipeline_config.coda_sync.sync_config, incremental_cache_path, dry_run)

--- a/sync_coda_to_engagement_db.py
+++ b/sync_coda_to_engagement_db.py
@@ -54,4 +54,7 @@ if __name__ == "__main__":
 
     if not args.skip_updating_coda_users_and_code_schemes:
         ensure_coda_users_and_code_schemes_up_to_date(coda, pipeline_config.coda_sync.sync_config, google_cloud_credentials_file_path, dry_run)
+    else:
+        log.warning("Skipping updating coda users and code schemes...")
+        
     sync_coda_to_engagement_db(coda, engagement_db, pipeline_config.coda_sync.sync_config, incremental_cache_path, dry_run)

--- a/sync_coda_to_engagement_db.py
+++ b/sync_coda_to_engagement_db.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
                         help="Logs the updates that would be made without updating anything.")
     parser.add_argument("--incremental-cache-path",
                         help="Path to a directory to use to cache results needed for incremental operation.")
-    parser.add_argument("-s", "--skip-coda-users-and-code-schemes-update", action="store_true",
+    parser.add_argument("-s", "--skip-updating-coda-users-and-code-schemes", action="store_true",
                         help="Whether to skip updating coda users and code schemes")
     parser.add_argument("user", help="Identifier of the user launching this program")
     parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
@@ -53,6 +53,6 @@ if __name__ == "__main__":
     engagement_db = pipeline_config.engagement_database.init_engagement_db_client(google_cloud_credentials_file_path)
     coda = pipeline_config.coda_sync.coda.init_coda_client(google_cloud_credentials_file_path)
 
-    if not args.skip_coda_users_and_code_schemes_update:
+    if not args.skip_updating_coda_users_and_code_schemes:
         ensure_coda_users_and_code_schemes_up_to_date(coda, pipeline_config.coda_sync.sync_config, google_cloud_credentials_file_path, dry_run)
     sync_coda_to_engagement_db(coda, engagement_db, pipeline_config.coda_sync.sync_config, incremental_cache_path, dry_run)

--- a/sync_coda_to_engagement_db.py
+++ b/sync_coda_to_engagement_db.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     parser.add_argument("--incremental-cache-path",
                         help="Path to a directory to use to cache results needed for incremental operation.")
     parser.add_argument("-s", "--skip-coda-users-and-code-schemes-update", action="store_true",
-                        help="Whether to skip coda users and code schemes updates")
+                        help="Whether to skip updating coda users and code schemes")
     parser.add_argument("user", help="Identifier of the user launching this program")
     parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
                         help="Path to a Google Cloud service account credentials file to use to access the "

--- a/sync_engagement_db_to_coda.py
+++ b/sync_engagement_db_to_coda.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
                         help="Logs the updates that would be made without updating anything.")
     parser.add_argument("--incremental-cache-path",
                         help="Path to a directory to use to cache results needed for incremental operation.")
-    parser.add_argument("-s", "--skip-coda-users-and-code-schemes-update", action="store_true",
+    parser.add_argument("-s", "--skip-updating-coda-users-and-code-schemes", action="store_true",
                         help="Whether to skip updating coda users and code schemes")
     parser.add_argument("user", help="Identifier of the user launching this program")
     parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
@@ -53,6 +53,6 @@ if __name__ == "__main__":
     engagement_db = pipeline_config.engagement_database.init_engagement_db_client(google_cloud_credentials_file_path)
     coda = pipeline_config.coda_sync.coda.init_coda_client(google_cloud_credentials_file_path)
 
-    if not args.skip_coda_users_and_code_schemes_update:
+    if not args.skip_updating_coda_users_and_code_schemes:
         ensure_coda_users_and_code_schemes_up_to_date(coda, pipeline_config.coda_sync.sync_config, google_cloud_credentials_file_path, dry_run)
     sync_engagement_db_to_coda(engagement_db, coda, pipeline_config.coda_sync.sync_config, incremental_cache_path, dry_run)

--- a/sync_engagement_db_to_coda.py
+++ b/sync_engagement_db_to_coda.py
@@ -17,6 +17,8 @@ if __name__ == "__main__":
                         help="Logs the updates that would be made without updating anything.")
     parser.add_argument("--incremental-cache-path",
                         help="Path to a directory to use to cache results needed for incremental operation.")
+    parser.add_argument("-s", "--skip-coda-users-and-code-schemes-update", action="store_true",
+                        help="Whether to skip coda users and code schemes updates")
     parser.add_argument("user", help="Identifier of the user launching this program")
     parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
                         help="Path to a Google Cloud service account credentials file to use to access the "
@@ -51,5 +53,6 @@ if __name__ == "__main__":
     engagement_db = pipeline_config.engagement_database.init_engagement_db_client(google_cloud_credentials_file_path)
     coda = pipeline_config.coda_sync.coda.init_coda_client(google_cloud_credentials_file_path)
 
-    ensure_coda_datasets_up_to_date(coda, pipeline_config.coda_sync.sync_config, google_cloud_credentials_file_path, dry_run)
+    if not args.skip_coda_users_and_code_schemes_update:
+        ensure_coda_datasets_up_to_date(coda, pipeline_config.coda_sync.sync_config, google_cloud_credentials_file_path, dry_run)
     sync_engagement_db_to_coda(engagement_db, coda, pipeline_config.coda_sync.sync_config, incremental_cache_path, dry_run)

--- a/sync_engagement_db_to_coda.py
+++ b/sync_engagement_db_to_coda.py
@@ -6,7 +6,7 @@ from core_data_modules.logging import Logger
 from engagement_database.data_models import HistoryEntryOrigin
 
 from src.engagement_db_coda_sync.engagement_db_to_coda import sync_engagement_db_to_coda
-from src.engagement_db_coda_sync.lib import ensure_coda_datasets_up_to_date
+from src.engagement_db_coda_sync.lib import ensure_coda_users_and_code_schemes_up_to_date
 
 log = Logger(__name__)
 
@@ -54,5 +54,5 @@ if __name__ == "__main__":
     coda = pipeline_config.coda_sync.coda.init_coda_client(google_cloud_credentials_file_path)
 
     if not args.skip_coda_users_and_code_schemes_update:
-        ensure_coda_datasets_up_to_date(coda, pipeline_config.coda_sync.sync_config, google_cloud_credentials_file_path, dry_run)
+        ensure_coda_users_and_code_schemes_up_to_date(coda, pipeline_config.coda_sync.sync_config, google_cloud_credentials_file_path, dry_run)
     sync_engagement_db_to_coda(engagement_db, coda, pipeline_config.coda_sync.sync_config, incremental_cache_path, dry_run)

--- a/sync_engagement_db_to_coda.py
+++ b/sync_engagement_db_to_coda.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     parser.add_argument("--incremental-cache-path",
                         help="Path to a directory to use to cache results needed for incremental operation.")
     parser.add_argument("-s", "--skip-coda-users-and-code-schemes-update", action="store_true",
-                        help="Whether to skip coda users and code schemes updates")
+                        help="Whether to skip updating coda users and code schemes")
     parser.add_argument("user", help="Identifier of the user launching this program")
     parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
                         help="Path to a Google Cloud service account credentials file to use to access the "


### PR DESCRIPTION
This enables one to update coda users and code schemes once in a pipeline run.