### PR TITLE
Fix docker build not working due to target directory not ending with '/'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ RUN pipenv sync
 # Copy the rest of the project
 ADD .git /app/.git
 ADD src /app/src
-ADD *.py /app
+ADD *.py /app/
 


### PR DESCRIPTION
I saw this for the first time today on a clean Ubuntu 22.04 install with the latest Docker.
The full error was: "When using ADD with more than one source file, the destination must be a directory and end with a /"
