### PR TITLE
Fetch duplicate origin ids

### DIFF
--- a/fetch_duplicate_origin_ids.py
+++ b/fetch_duplicate_origin_ids.py
@@ -93,6 +93,7 @@ if __name__ == "__main__":
     duplicate_origin_ids = get_duplicate_origin_ids_in_datasets(engagement_db, list(engagement_db_datasets), cache, dry_run)
 
     fields = ["origin_id", "engagement_db_datasets", "duplicate_origin_id_count"]
+    log.info(f"Exporting duplicate origin ids to {duplicate_origin_ids_output_path}")
     with open(duplicate_origin_ids_output_path, "w") as csvfile:
         csvwriter = csv.writer(csvfile)
         csvwriter.writerow(fields) 

--- a/fetch_duplicate_origin_ids.py
+++ b/fetch_duplicate_origin_ids.py
@@ -1,0 +1,99 @@
+import argparse
+import csv
+import importlib
+
+from core_data_modules.logging import Logger
+
+from src.common.cache import Cache
+from src.common.get_messages_in_datasets import get_duplicate_messages_in_datasets
+
+
+def get_engagement_db_datasets(pipeline_config):
+    engagement_db_datasets = set()
+    if pipeline_config.google_form_sources is not None:
+        for google_form_source in pipeline_config.google_form_sources:
+            for config in google_form_source.sync_config.question_configurations:
+                if config.engagement_db_dataset not in engagement_db_datasets:
+                    engagement_db_datasets.add(config.engagement_db_dataset)
+
+    if pipeline_config.rapid_pro_sources is not None:
+        for rapid_pro_source in pipeline_config.rapid_pro_sources:
+            for config in rapid_pro_source.sync_config.flow_result_configurations:
+                if config.engagement_db_dataset not in engagement_db_datasets:
+                    engagement_db_datasets.add(config.engagement_db_dataset)
+
+    if pipeline_config.facebook_sources is not None:
+        for facebook_source in pipeline_config.facebook_sources:
+            for facebook_dataset in facebook_source.datasets:
+                if facebook_dataset.engagement_db_dataset not in engagement_db_datasets:
+                    engagement_db_datasets.add(facebook_dataset.engagement_db_dataset)
+
+    if pipeline_config.telegram_group_sources is not None:
+        for telegram_group_source in pipeline_config.telegram_group_sources:
+            for telegram_group_dataset in telegram_group_source.datasets:
+                if telegram_group_dataset.engagement_db_dataset not in engagement_db_datasets:
+                    engagement_db_datasets.add(telegram_group_dataset.engagement_db_dataset)
+
+    if pipeline_config.csv_sources is not None:
+        for csv_source in pipeline_config.csv_sources:
+            for config in csv_source.engagement_db_datasets:
+                if config.engagement_db_dataset not in engagement_db_datasets:
+                    engagement_db_datasets.add(csv_source.engagement_db_dataset)
+
+    return list(engagement_db_datasets)
+
+
+log = Logger(__name__)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Gets messages from all datasets, computes duplicate"
+                                                 "origin ids in engagement db and writes them in a csv")
+
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Logs the updates that would be made without updating anything.")
+    parser.add_argument("--incremental-cache-path",
+                        help="Path to a directory to use to cache results needed for incremental operation.")
+
+    parser.add_argument("user", help="Identifier of the user launching this program")
+    parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
+                        help="Path to a Google Cloud service account credentials file to use to access the "
+                             "credentials bucket"),
+    parser.add_argument("configuration_module",
+                        help="Configuration module to import e.g. 'configurations.test_config'. "
+                             "This module must contain a PIPELINE_CONFIGURATION property")
+    parser.add_argument("duplicate_origin_ids_output_path", metavar="duplicate-origin-ids-output-path",
+                        help="Path to write the duplicate origin ids CSV to")
+
+    args = parser.parse_args()
+
+    dry_run = args.dry_run
+    incremental_cache_path = args.incremental_cache_path
+
+    user = args.user
+    google_cloud_credentials_file_path = args.google_cloud_credentials_file_path
+    pipeline_config = importlib.import_module(args.configuration_module).PIPELINE_CONFIGURATION
+    duplicate_origin_ids_output_path = args.duplicate_origin_ids_output_path
+
+    pipeline = pipeline_config.pipeline_name
+
+    dry_run_text = "(dry run)" if dry_run else ""
+    log.info(f"Computing duplicate engagement db origin ids in pipeline: {pipeline} {dry_run_text}")
+
+    engagement_db = pipeline_config.engagement_database.init_engagement_db_client(google_cloud_credentials_file_path)
+    engagement_db_datasets = get_engagement_db_datasets(pipeline_config)
+    log.info(f"Found {len(engagement_db_datasets)} engagement db datasets from the data sources configured in {pipeline} pipeline")
+
+    if incremental_cache_path is None:
+        cache = None
+        log.warning(f"No `cache_path` provided. This tool will perform a full download of project messages from engagement database")
+    else:
+        log.info(f"Initialising Cache at '{incremental_cache_path}/raw_engement_db_messages'")
+        cache = Cache(f"{incremental_cache_path}/raw_engement_db_messages")
+
+    duplicate_origin_ids = get_duplicate_origin_ids_in_datasets(engagement_db, list(engagement_db_datasets), cache, dry_run)
+
+    fields = ["origin_id", "engagement_db_datasets", "duplicate_origin_id_count"]
+    with open(duplicate_origin_ids_output_path, "w") as csvfile:
+        csvwriter = csv.writer(csvfile)
+        csvwriter.writerow(fields) 
+        csvwriter.writerows(duplicate_origin_ids)

--- a/fetch_duplicate_origin_ids.py
+++ b/fetch_duplicate_origin_ids.py
@@ -5,7 +5,7 @@ import importlib
 from core_data_modules.logging import Logger
 
 from src.common.cache import Cache
-from src.common.get_messages_in_datasets import get_duplicate_messages_in_datasets
+from src.common.get_messages_in_datasets import get_duplicate_origin_ids_in_datasets
 
 
 def get_engagement_db_datasets(pipeline_config):

--- a/src/common/get_messages_in_datasets.py
+++ b/src/common/get_messages_in_datasets.py
@@ -26,7 +26,7 @@ def filter_latest_message_snapshots(messages):
     return latest_messages
 
 
-def get_messages_in_datasets(engagement_db, engagement_db_datasets, cache=None, dry_run=False):
+def _get_raw_messages_in_datasets(engagement_db, engagement_db_datasets, cache=None, dry_run=False):
     """
     Gets messages in the specified datasets.
 

--- a/src/common/get_messages_in_datasets.py
+++ b/src/common/get_messages_in_datasets.py
@@ -153,6 +153,11 @@ def _get_raw_messages_in_datasets(engagement_db, engagement_db_datasets, cache=N
     log.info(f"Filtered for latest message snapshots across all datasets: "
              f"{len(all_latest_messages)}/{len(all_messages)} snapshots remain")
 
+    return engagement_db_messages_map
+
+
+def get_relevant_messages_in_datasets(engagement_db, engagement_db_datasets, cache=None, dry_run=False):
+    engagement_db_messages_map = _get_raw_messages_in_datasets(engagement_db, engagement_db_datasets, cache, dry_run)
     # Ensure that origin_ids in the exported messages are all unique. If we have multiple messages with the same
     # origin_id, that means there is a problem with the database or with the cache.
     # (Most likely we added the same message twice or we deleted a message and forgot to delete the analysis cache).

--- a/src/engagement_db_to_analysis/engagement_db_to_analysis.py
+++ b/src/engagement_db_to_analysis/engagement_db_to_analysis.py
@@ -3,7 +3,7 @@ from core_data_modules.traced_data import TracedData, Metadata
 from core_data_modules.traced_data.io import TracedDataJsonIO
 from core_data_modules.util import TimeUtils
 
-from src.common.get_messages_in_datasets import get_messages_in_datasets
+from src.common.get_messages_in_datasets import get_relevant_messages_in_datasets
 from src.engagement_db_to_analysis import google_drive_upload
 from src.engagement_db_to_analysis.analysis_files import export_production_file, export_analysis_file
 from src.engagement_db_to_analysis.automated_analysis import run_automated_analysis
@@ -67,7 +67,7 @@ def generate_analysis_files(user, google_cloud_credentials_file_path, pipeline_c
     engagement_db_datasets = []
     for config in analysis_dataset_configurations:
         engagement_db_datasets.extend(config.engagement_db_datasets)
-    messages_map = get_messages_in_datasets(engagement_db, engagement_db_datasets, cache, dry_run)
+    messages_map = get_relevant_messages_in_datasets(engagement_db, engagement_db_datasets, cache, dry_run)
 
     messages_traced_data = _convert_messages_to_traced_data(user, messages_map)
 

--- a/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
+++ b/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
@@ -7,7 +7,7 @@ from core_data_modules.data_models import CodeScheme
 from core_data_modules.logging import Logger
 
 from src.common.cache import Cache
-from src.common.get_messages_in_datasets import get_messages_in_datasets
+from src.common.get_messages_in_datasets import get_relevant_messages_in_datasets
 from src.engagement_db_to_rapid_pro.configuration import WriteModes
 
 log = Logger(__name__)
@@ -50,7 +50,7 @@ def _get_all_messages(engagement_db, sync_config, cache=None):
     :rtype: list of engagement_database.data_models.Message
     """
     engagement_db_datasets = _engagement_db_datasets_in_sync_config(sync_config)
-    messages_by_dataset = get_messages_in_datasets(engagement_db, engagement_db_datasets, cache)
+    messages_by_dataset = get_relevant_messages_in_datasets(engagement_db, engagement_db_datasets, cache)
 
     messages = []
     for msgs in messages_by_dataset.values():


### PR DESCRIPTION
Fetches duplicate origins in the engagement database if they exist and writes them in a CSV file to inform the next step that is, either clearing the cache if it has issues or else deleting them from DB.