### PR TITLE
Fix gh deprecation warnings

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Log in to the container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -19,7 +19,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # For convenience, tag builds with the branch name and/or tag name where applicable.
@@ -30,7 +30,7 @@ jobs:
             type=raw,priority=1,value=build-${{github.run_id}}-attempt-${{github.run_attempt}}
 
       - name: Build and push the image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to the container registry
         uses: docker/login-action@v1


### PR DESCRIPTION
Example of a build with warnings: https://github.com/AfricasVoices/Engagement-Data-Pipeline/actions/runs/3524481441 

This will keep our builds working past May 2023.