### PR TITLE
Only run the ARM installation steps when running on an ARM architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.8-slim
 RUN apt-get update && apt-get install -y git
 RUN pip install pipenv
 
-# ARM support
-RUN apt-get update && apt-get install -y libgeos-dev libgdal-dev build-essential
+# If building for ARM-64 architecture, install additional dependencies which will be needed to run `pipenv sync` later.
+RUN if [ $(arch) = 'aarch64' ]; then apt-get update && apt-get install -y libgeos-dev libgdal-dev build-essential; fi
 
 # Make a directory for private credentials files
 RUN mkdir /credentials


### PR DESCRIPTION
This makes the images smaller in production automatically.