### PR TITLE
Simplify regression analysis data conversion

### DIFF
--- a/src/engagement_db_to_analysis/automated_analysis.py
+++ b/src/engagement_db_to_analysis/automated_analysis.py
@@ -8,7 +8,8 @@ from src.engagement_db_to_analysis.column_view_conversion import (analysis_datas
                                                                   analysis_dataset_configs_to_demog_column_configs,
                                                                   analysis_dataset_configs_to_column_configs)
 from src.engagement_db_to_analysis.configuration import AnalysisLocations
-from src.engagement_db_to_analysis.regression_analysis.regression_analysis import export_all_regression_analysis_txt
+from src.engagement_db_to_analysis.regression_analysis.complete_case_regression_analysis import (
+    export_all_complete_case_regression_analysis_txt)
 
 log = Logger(__name__)
 
@@ -105,7 +106,7 @@ def run_automated_analysis(messages_by_column, participants_by_column, analysis_
     if analysis_config.enable_experimental_regression_analysis:
         log.info(f"Running experimental regression analysis...")
         with open(f"{export_dir_path}/complete_case_regression.txt", "w") as f:
-            export_all_regression_analysis_txt(
+            export_all_complete_case_regression_analysis_txt(
                 participants_by_column, "consent_withdrawn", rqa_column_configs, demog_column_configs, f
             )
 

--- a/src/engagement_db_to_analysis/regression_analysis/data_conversion.py
+++ b/src/engagement_db_to_analysis/regression_analysis/data_conversion.py
@@ -83,25 +83,6 @@ def _get_participant_regression_data(participant, consent_withdrawn_field, rqa_a
     return regression_data
 
 
-def _get_column_types(rqa_analysis_config, demog_analysis_configs):
-    """
-    Gets the expected types of the values returned by `_get_participant_regression_data`.
-
-    :param rqa_analysis_config: Configuration for the RQA dataset to include in the returned data-frame.
-    :type rqa_analysis_config: core_data_modules.analysis.AnalysisConfiguration
-    :param demog_analysis_configs: Configuration for the demographic datasets to include in the returned data-frame.
-    :type demog_analysis_configs: list of core_data_modules.analysis.AnalysisConfiguration
-    """
-    column_types = dict()
-    column_types["participant_uuid"] = str
-    for code in rqa_analysis_config.code_scheme.codes:
-        column_types[f"{rqa_analysis_config.dataset_name}_{code.string_value}"] = int
-    for demog_config in demog_analysis_configs:
-        column_types[demog_config.dataset_name] = str
-
-    return column_types
-
-
 def convert_participants_to_regression_data_frame(participants, consent_withdrawn_field,
                                                   rqa_analysis_config, demog_analysis_configs):
     """
@@ -138,5 +119,4 @@ def convert_participants_to_regression_data_frame(participants, consent_withdraw
         )
 
     # Convert the regression data into an R data frame.
-    column_types = _get_column_types(rqa_analysis_config, demog_analysis_configs)
-    return convert_dicts_to_r_data_frame(regression_dicts, column_types)
+    return convert_dicts_to_r_data_frame(regression_dicts)

--- a/src/engagement_db_to_analysis/regression_analysis/data_conversion.py
+++ b/src/engagement_db_to_analysis/regression_analysis/data_conversion.py
@@ -7,7 +7,7 @@ from core_data_modules.analysis.analysis_utils import get_codes_from_td
 from core_data_modules.analysis.cross_tabs import _normal_codes
 from core_data_modules.cleaners import Codes
 
-from src.engagement_db_to_analysis.regression_analysis.r_utils import convert_dicts_to_r_data_frame
+from src.engagement_db_to_analysis.regression_analysis.r_utils import convert_dicts_to_r_data_frame_of_factors
 
 
 def _get_matrix_values(codes, dataset_name, code_scheme):
@@ -119,4 +119,4 @@ def convert_participants_to_regression_data_frame(participants, consent_withdraw
         )
 
     # Convert the regression data into an R data frame.
-    return convert_dicts_to_r_data_frame(regression_dicts)
+    return convert_dicts_to_r_data_frame_of_factors(regression_dicts)

--- a/src/engagement_db_to_analysis/regression_analysis/r_utils.py
+++ b/src/engagement_db_to_analysis/regression_analysis/r_utils.py
@@ -1,18 +1,15 @@
 # TODO: Move to CoreDataModules once stable
 from collections import defaultdict
 
-from rpy2.robjects import DataFrame, IntVector, StrVector
+from rpy2.robjects import DataFrame, FactorVector
 
 
-def convert_dicts_to_r_data_frame(dicts, types):
+def convert_dicts_to_r_data_frame(dicts):
     """
     Converts a list of dictionaries to an R data-frame.
 
     :param dicts: Dictionaries to convert. Every dictionary must contain the same keys.
     :type dicts: dict of str -> (str | int | None)
-    :param types: Dictionary mapping each key in the `dicts` to the type of that key's values in the `dicts`, so we can
-                  convert to the correct data-type in R. Supported types are str and int.
-    :type types: dict of str -> type
     """
     if len(dicts) == 0:
         return DataFrame({})
@@ -20,7 +17,7 @@ def convert_dicts_to_r_data_frame(dicts, types):
     # Ensure every dict contains the same keys
     keys = set(dicts[0].keys())
     for d in dicts:
-        assert set(d.keys()) == keys
+        assert set(d.keys()) == keys, f"{set(d.keys())}, {keys}"
 
     # R data-frames are constructed from a dict of (column_name) -> (values_vector), where
     # the nth row of the created data_frame contains the values at the nth position of each values_vector.
@@ -30,16 +27,12 @@ def convert_dicts_to_r_data_frame(dicts, types):
     lists = defaultdict(list)
     for d in dicts:
         for (k, v) in d.items():
-            lists[k].append(v)
+            lists[k].append(None if v is None else str(v))
 
     # 2. Convert each list of values to an R vector
     vectors = dict()
     for (dataset_name, values) in lists.items():
-        if types[dataset_name] == int:
-            vectors[dataset_name] = IntVector(values)
-        else:
-            assert types[dataset_name] == str, types[dataset_name]
-            vectors[dataset_name] = StrVector(values)
+        vectors[dataset_name] = FactorVector(values)
 
     # 3. Convert the R vectors to an R data frame
     return DataFrame(vectors)

--- a/src/engagement_db_to_analysis/regression_analysis/r_utils.py
+++ b/src/engagement_db_to_analysis/regression_analysis/r_utils.py
@@ -8,6 +8,9 @@ def convert_dicts_to_r_data_frame(dicts):
     """
     Converts a list of dictionaries to an R data-frame.
 
+    Each column in the returned data-frame contains a "FactorVector", which is the datatype used to represent
+    categorical data in R.
+
     :param dicts: Dictionaries to convert. Every dictionary must contain the same keys.
     :type dicts: dict of str -> (str | int | None)
     """

--- a/src/engagement_db_to_analysis/regression_analysis/r_utils.py
+++ b/src/engagement_db_to_analysis/regression_analysis/r_utils.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from rpy2.robjects import DataFrame, FactorVector
 
 
-def convert_dicts_to_r_data_frame(dicts):
+def convert_dicts_to_r_data_frame_of_factors(dicts):
     """
     Converts a list of dictionaries to an R data-frame.
 


### PR DESCRIPTION
Using IntVectors and StrVectors was unnecessarily complicated and will not work when we run multiple imputation. FactorVector is the correct conversion to use instead.