### PR TITLE
Upgrade Firestore filters to use the new filter keyword

### DIFF
--- a/src/csv_to_engagement_db/csv_to_engagement_db.py
+++ b/src/csv_to_engagement_db/csv_to_engagement_db.py
@@ -10,6 +10,8 @@ from core_data_modules.logging import Logger
 from core_data_modules.util import SHAUtils
 from engagement_database.data_models import (HistoryEntryOrigin, Message, MessageDirections, MessageOrigin,
                                              MessageStatuses)
+from google.cloud.firestore_v1 import FieldFilter
+
 from src.common.cache import Cache
 from src.csv_to_engagement_db.sync_stats import CSVSyncEvents, CSVToEngagementDBDatasetSyncStats, CSVToEngagementDBSyncStats
 from storage.google_cloud import google_cloud_utils
@@ -96,7 +98,7 @@ def _engagement_db_has_message(engagement_db, message):
     :return: Whether a message with this text, timestamp, and participant_uuid exists in the engagement database.
     :rtype: bool
     """
-    matching_messages_filter = lambda q: q.where("origin.origin_id", "==", message.origin.origin_id)
+    matching_messages_filter = lambda q: q.where(filter=FieldFilter("origin.origin_id", "==", message.origin.origin_id))
     matching_messages = engagement_db.get_messages(firestore_query_filter=matching_messages_filter)
     assert len(matching_messages) < 2
 

--- a/src/engagement_db_coda_sync/coda_to_engagement_db.py
+++ b/src/engagement_db_coda_sync/coda_to_engagement_db.py
@@ -1,6 +1,7 @@
 from core_data_modules.logging import Logger
 from engagement_database.data_models import MessageStatuses
 from google.cloud import firestore
+from google.cloud.firestore_v1 import FieldFilter
 
 from src.engagement_db_coda_sync.cache import CodaSyncCache
 from src.engagement_db_coda_sync.lib import _update_engagement_db_message_from_coda_message
@@ -50,9 +51,9 @@ def _sync_coda_message_to_engagement_db_batch(transaction, coda, coda_message, e
 
     engagement_db_messages = engagement_db.get_messages(
         firestore_query_filter=lambda q: q
-            .where("dataset", "==", engagement_db_dataset)
-            .where("coda_id", "==", coda_message.message_id)
-            .where("status", "in", [MessageStatuses.LIVE, MessageStatuses.STALE])
+            .where(filter=FieldFilter("dataset", "==", engagement_db_dataset))
+            .where(filter=FieldFilter("coda_id", "==", coda_message.message_id))
+            .where(filter=FieldFilter("status", "in", [MessageStatuses.LIVE, MessageStatuses.STALE]))
             .order_by("last_updated")
             .order_by("message_id")
             .start_after(start_after_dict)

--- a/src/engagement_db_coda_sync/engagement_db_to_coda.py
+++ b/src/engagement_db_coda_sync/engagement_db_to_coda.py
@@ -2,6 +2,7 @@ from core_data_modules.logging import Logger
 from core_data_modules.util import SHAUtils
 from engagement_database.data_models import MessageStatuses, HistoryEntryOrigin
 from google.cloud import firestore
+from google.cloud.firestore_v1 import FieldFilter
 
 from src.engagement_db_coda_sync.cache import CodaSyncCache
 from src.engagement_db_coda_sync.lib import _update_engagement_db_message_from_coda_message, _add_message_to_coda
@@ -44,8 +45,8 @@ def _sync_next_engagement_db_message_to_coda(transaction, engagement_db, coda, c
     """
     if last_seen_message is None:
         messages_filter = lambda q: q \
-            .where("status", "in", [MessageStatuses.LIVE, MessageStatuses.STALE]) \
-            .where("dataset", "==", dataset_config.engagement_db_dataset) \
+            .where(filter=FieldFilter("status", "in", [MessageStatuses.LIVE, MessageStatuses.STALE])) \
+            .where(filter=FieldFilter("dataset", "==", dataset_config.engagement_db_dataset)) \
             .order_by("last_updated") \
             .order_by("message_id") \
             .limit(1)
@@ -53,11 +54,11 @@ def _sync_next_engagement_db_message_to_coda(transaction, engagement_db, coda, c
         # Get the next message after the last_seen_message, having sorted by last_updated than message_id
         # Note: The last_seen_message can be the next/later message to be synced if it was updated
         messages_filter = lambda q: q \
-            .where("status", "in", [MessageStatuses.LIVE, MessageStatuses.STALE]) \
-            .where("dataset", "==", dataset_config.engagement_db_dataset) \
+            .where(filter=FieldFilter("status", "in", [MessageStatuses.LIVE, MessageStatuses.STALE])) \
+            .where(filter=FieldFilter("dataset", "==", dataset_config.engagement_db_dataset)) \
             .order_by("last_updated") \
             .order_by("message_id") \
-            .where("last_updated", ">=", last_seen_message.last_updated) \
+            .where(filter=FieldFilter("last_updated", ">=", last_seen_message.last_updated)) \
             .start_after({"last_updated": last_seen_message.last_updated, "message_id": last_seen_message.message_id}) \
             .limit(1)
 

--- a/src/facebook_to_engagement_db/facebook_to_engagement_db.py
+++ b/src/facebook_to_engagement_db/facebook_to_engagement_db.py
@@ -1,7 +1,7 @@
 from dateutil.parser import isoparse
 import csv
 
-
+from google.cloud.firestore_v1 import FieldFilter
 from storage.google_cloud import google_cloud_utils
 from social_media_tools.facebook import (FacebookClient, facebook_utils)
 from core_data_modules.logging import Logger
@@ -61,7 +61,7 @@ def _engagement_db_has_message(engagement_db, message):
     :return: Whether a message with this text, timestamp, and participant_uuid exists in the engagement database.
     :rtype: bool
     """
-    matching_messages_filter = lambda q: q.where("origin.origin_id", "==", message.origin.origin_id)
+    matching_messages_filter = lambda q: q.where(filter=FieldFilter("origin.origin_id", "==", message.origin.origin_id))
     matching_messages = engagement_db.get_messages(firestore_query_filter=matching_messages_filter)
     assert len(matching_messages) < 2
 

--- a/src/google_form_to_engagement_db/google_form_to_engagement_db.py
+++ b/src/google_form_to_engagement_db/google_form_to_engagement_db.py
@@ -5,6 +5,7 @@ from core_data_modules.logging import Logger
 from dateutil.parser import isoparse
 from engagement_database.data_models import (Message, MessageDirections, MessageStatuses, MessageOrigin,
                                              HistoryEntryOrigin)
+from google.cloud.firestore_v1 import FieldFilter
 
 from src.common.cache import Cache
 from src.google_form_to_engagement_db.configuration import GoogleFormParticipantIdTypes
@@ -244,7 +245,7 @@ def _engagement_db_has_message(engagement_db, message):
     :return: Whether a message with this text, timestamp, and participant_uuid exists in the engagement database.
     :rtype: bool
     """
-    matching_messages_filter = lambda q: q.where("origin.origin_id", "==", message.origin.origin_id)
+    matching_messages_filter = lambda q: q.where(filter=FieldFilter("origin.origin_id", "==", message.origin.origin_id))
     matching_messages = engagement_db.get_messages(firestore_query_filter=matching_messages_filter)
     assert len(matching_messages) < 2, f"Expected at most 1 matching message in database, but found {len(matching_messages)}."
 

--- a/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
+++ b/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
@@ -6,6 +6,7 @@ from core_data_modules.cleaners import URNCleaner
 from core_data_modules.logging import Logger
 from engagement_database.data_models import (Message, MessageDirections, MessageStatuses, HistoryEntryOrigin,
                                              MessageOrigin)
+from google.cloud.firestore_v1 import FieldFilter
 from storage.google_cloud import google_cloud_utils
 
 from src.rapid_pro_to_engagement_db.cache import RapidProSyncCache
@@ -133,7 +134,7 @@ def _engagement_db_has_message(engagement_db, message):
     :return: Whether a message with this text, timestamp, and participant_uuid exists in the engagement database.
     :rtype: bool
     """
-    matching_messages_filter = lambda q: q.where("origin.origin_id", "==", message.origin.origin_id)
+    matching_messages_filter = lambda q: q.where(filter=FieldFilter("origin.origin_id", "==", message.origin.origin_id))
     matching_messages = engagement_db.get_messages(firestore_query_filter=matching_messages_filter)
     assert len(matching_messages) < 2
 
@@ -258,7 +259,7 @@ def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_
                     cache.set_latest_run_timestamp(flow_id, run.modified_on)
                 continue
             contact = contacts_lut[run.contact.uuid]
-            assert len(contact.urns) == 1, len(contact.urns)
+            # assert len(contact.urns) == 1, len(contact.urns)
             contact_urn = _normalise_and_validate_contact_urn(contact.urns[0])
 
             if rapid_pro_config.uuid_filter is not None:

--- a/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
+++ b/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
@@ -259,7 +259,7 @@ def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_
                     cache.set_latest_run_timestamp(flow_id, run.modified_on)
                 continue
             contact = contacts_lut[run.contact.uuid]
-            # assert len(contact.urns) == 1, len(contact.urns)
+            assert len(contact.urns) == 1, len(contact.urns)
             contact_urn = _normalise_and_validate_contact_urn(contact.urns[0])
 
             if rapid_pro_config.uuid_filter is not None:

--- a/src/telegram_to_engagement_db/telegram_group_to_engagement_db.py
+++ b/src/telegram_to_engagement_db/telegram_group_to_engagement_db.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import json
 
+from google.cloud.firestore_v1 import FieldFilter
 from telethon import TelegramClient
 from telethon.errors import SessionPasswordNeededError
 from telethon.tl.types import (PeerChannel)
@@ -157,7 +158,7 @@ def _engagement_db_has_message(engagement_db, message):
     :return: Whether a message with this text, timestamp, and participant_uuid exists in the engagement database.
     :rtype: bool
     """
-    matching_messages_filter = lambda q: q.where("origin.origin_id", "==", message.origin.origin_id)
+    matching_messages_filter = lambda q: q.where(filter=FieldFilter("origin.origin_id", "==", message.origin.origin_id))
     matching_messages = engagement_db.get_messages(firestore_query_filter=matching_messages_filter)
     assert len(matching_messages) < 2
 


### PR DESCRIPTION
This fixes these warnings being generated by this repo: "UserWarning: Detected filter using positional arguments. Prefer using the 'filter' keyword argument instead."