### PR TITLE
Set Exit Code to 1 for Usage Errors

### DIFF
--- a/archive_data_dir.sh
+++ b/archive_data_dir.sh
@@ -5,7 +5,7 @@ set -e
 if [[ $# -ne 2 ]]; then
     echo "Usage: ./archive_data_dir <data-dir> <archive-file>"
     echo "Backs-up the data root directory to a compressed file in at the specified location"
-    exit
+    exit 1
 fi
 
 DATA_DIR=$1

--- a/docker-run-engagement-db-to-analysis.sh
+++ b/docker-run-engagement-db-to-analysis.sh
@@ -27,7 +27,7 @@ if [[ $# -ne 5 ]]; then
     echo "Usage: $0 
     [--dry-run] [--incremental-cache-volume <incremental-cache-volume>] 
     <user> <google-cloud-credentials-file-path> <configuration-module> <code-schemes-dir> <data-dir>"
-    exit
+    exit 1
 fi
 
 # Assign the program arguments to bash variables.

--- a/docker-run-facebook-to-engagement-db.sh
+++ b/docker-run-facebook-to-engagement-db.sh
@@ -24,7 +24,7 @@ if [[ $# -ne 5 ]]; then
     echo "Usage: $0 
     [--incremental-cache-volume <incremental-cache-volume>] 
     <user> <google-cloud-credentials-file-path> <configuration-file> <code-schemes-dir> <data-dir>"
-    exit
+    exit 1
 fi
 
 # Assign the program arguments to bash variables.

--- a/docker-run-log-pipeline-event.sh
+++ b/docker-run-log-pipeline-event.sh
@@ -11,7 +11,7 @@ if [[ $# -ne 4 ]]; then
     [--profile-cpu <cpu-profile-output-path>] <configuration-module> <google-cloud-credentials-file-path> \
      <run-id> <event-key>"
     echo "Updates pipeline event/status to a firebase table to aid in monitoring"
-    exit
+    exit 1
 fi
 # Assign the program arguments to bash variables.
 CONFIGURATION_MODULE=$1

--- a/docker-run-telegram-group-to-engagement-db.sh
+++ b/docker-run-telegram-group-to-engagement-db.sh
@@ -24,7 +24,7 @@ if [[ $# -ne 5 ]]; then
     echo "Usage: $0
     [--incremental-cache-volume <incremental-cache-volume>]
     <user> <google-cloud-credentials-file-path> <configuration-file> <code-schemes-dir> <data-dir>"
-    exit
+    exit 1
 fi
 
 # Assign the program arguments to bash variables.

--- a/docker-run-upload-archive-files.sh
+++ b/docker-run-upload-archive-files.sh
@@ -9,7 +9,7 @@ IMAGE_NAME=$PROJECT_NAME-upload-archive-files
 if [[ $# -ne 4 ]]; then
     echo "Usage: ./docker-run-upload-archive-files.sh
      <user> <google-cloud-credentials-file-path> <configuration-module> <archive-dir>"
-    exit
+    exit 1
 fi
 # Assign the program arguments to bash variables.
 USER=$1

--- a/docker-sync-coda-to-engagement-db.sh
+++ b/docker-sync-coda-to-engagement-db.sh
@@ -27,7 +27,7 @@ if [[ $# -ne 5 ]]; then
     echo "Usage: $0 
     [--dry-run] [--incremental-cache-volume <incremental-cache-volume>]
     <user> <google-cloud-credentials-file-path> <configuration-file> <code-schemes-dir> <data-dir>"
-    exit
+    exit 1
 fi
 
 # Assign the program arguments to bash variables.

--- a/docker-sync-csvs-to-engagement-db.sh
+++ b/docker-sync-csvs-to-engagement-db.sh
@@ -27,7 +27,7 @@ if [[ $# -ne 5 ]]; then
     echo "Usage: $0 
     [--dry-run] [--incremental-cache-volume <incremental-cache-volume>] 
     <user> <google-cloud-credentials-file-path> <configuration-file> <code-schemes-dir> <data-dir>"
-    exit
+    exit 1
 fi
 
 # Assign the program arguments to bash variables.

--- a/docker-sync-engagement-db-to-coda.sh
+++ b/docker-sync-engagement-db-to-coda.sh
@@ -27,7 +27,7 @@ if [[ $# -ne 5 ]]; then
     echo "Usage: $0 
     [--dry-run] [--incremental-cache-volume <incremental-cache-volume>]
     <user> <google-cloud-credentials-file-path> <configuration-file> <code-schemes-dir> <data-dir>"
-    exit
+    exit 1
 fi
 
 # Assign the program arguments to bash variables.

--- a/docker-sync-engagement-db-to-rapid-pro.sh
+++ b/docker-sync-engagement-db-to-rapid-pro.sh
@@ -27,7 +27,7 @@ if [[ $# -ne 4 ]]; then
     echo "Usage: $0
     [--dry-run] [--incremental-cache-volume <incremental-cache-volume>]
     <user> <google-cloud-credentials-file-path> <configuration-file> <code-schemes-dir>"
-    exit
+    exit 1
 fi
 
 # Assign the program arguments to bash variables.

--- a/docker-sync-google-forms-to-engagement-db.sh
+++ b/docker-sync-google-forms-to-engagement-db.sh
@@ -27,7 +27,7 @@ if [[ $# -ne 5 ]]; then
     echo "Usage: $0 
     [--dry-run] [--incremental-cache-volume <incremental-cache-volume>] 
     <user> <google-cloud-credentials-file-path> <configuration-file> <code-schemes-dir> <data-dir>"
-    exit
+    exit 1
 fi
 
 # Assign the program arguments to bash variables.

--- a/docker-sync-rapid-pro-to-engagement-db.sh
+++ b/docker-sync-rapid-pro-to-engagement-db.sh
@@ -31,7 +31,7 @@ if [[ $# -ne 5 ]]; then
     [--dry-run] [--incremental-cache-volume <incremental-cache-volume>] 
     [--local-archive <local_archive>] : set a single option with argument, repeat it multiple times
     <user> <google-cloud-credentials-file-path> <configuration-file> <code-schemes-dir> <data-dir>"
-    exit
+    exit 1
 fi
 
 # Assign the program arguments to bash variables.

--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -8,7 +8,7 @@ if [[ $# -ne 6 ]]; then
     echo "  <user> <pipeline-name> <google-cloud-credentials-file-path> <configuration-module> <data-dir>"
     echo "Runs the pipeline end-to-end (sync-rapid-pro-to-engagement-db, sync-engagement-db-to-coda, sync-coda-to-engagement-db,\
           sync-engagement-db-to-rapid-pro, run-engagement-db-to-analysis, ARCHIVE)"
-    exit
+    exit 1
 fi
 
 USER=$1


### PR DESCRIPTION
## Changes Made
- Set the exit code to 1 to indicate a usage error when the expected number of command-line arguments is not provided.

## Details
The script now uses `exit 1` to signal a usage error when the number of expected arguments is not met. This makes the script behavior more explicit and aligns with the convention of using a non-zero exit code for errors.

## Implications
When running this script in another script with `set -e`, the script will exit immediately if a usage error occurs, providing an early indication of the problem.

## Context
In a previous use case, there was an incident where running `docker-run-engagement-db-to-analysis.sh` with the `--dry-run` flag failed due to the flag not being implemented. However, `run_pipeline.sh` did not exit, and it continued running other scripts.